### PR TITLE
fix(automation): update description mapping and add chapterName fallback

### DIFF
--- a/src/app/content/AgenticAI/Automation/BulkContentGenerate.tsx
+++ b/src/app/content/AgenticAI/Automation/BulkContentGenerate.tsx
@@ -23,7 +23,7 @@ const COLUMN_MAPPING: Record<string, string> = {
   "Job Role Category": "jobRoleCategory",
   "Chapter": "chapterName",
   "Topic": "chapterName",
-  "Description": "chapterName",
+  "Description": "chapter_desc",
   "Content Type": "contentType",
   "Type": "contentType",
   "Question": "question",
@@ -147,7 +147,10 @@ export default function BulkContentGenerate({ sessionData }: BulkContentGenerate
         // Keep the Excel values if they exist, don't override to 0
         mappedRow.contentType = "none";
       }
-      
+
+      // Fallback for chapterName if missing
+      mappedRow.chapterName = mappedRow.chapterName || mappedRow.jobrole;
+
       return mappedRow;
     });
   }, [rawExcelData]);


### PR DESCRIPTION
Update the COLUMN_MAPPING to map "Description" to "chapter_desc" instead of "chapterName".

Add a fallback mechanism in the row mapping logic to ensure `chapterName` is populated with `jobrole` if it is missing from the source data.