### PR TITLE
perf(api): reduce max_tokens for bulk content generation

### DIFF
--- a/src/app/api/bulk-content-generate/route.ts
+++ b/src/app/api/bulk-content-generate/route.ts
@@ -55,7 +55,7 @@ Output must be valid JSON in this exact format:
         },
         { role: "user", content: prompt }
       ],
-      max_tokens: 3000,
+      max_tokens: 2500,
       temperature: 0.0,
     }),
   });


### PR DESCRIPTION
Decrease the max_tokens limit from 3000 to 2500 in the bulk content generation API to optimize response constraints and prevent excessive token usage.