### PR TITLE
feat(hr-templates): enable offer automation and data injection

### DIFF
--- a/src/app/content/Telent-management/Offer-management/OfferDashboard.tsx
+++ b/src/app/content/Telent-management/Offer-management/OfferDashboard.tsx
@@ -198,6 +198,77 @@ export default function OfferDashboard({ showHeader = true, candidate, position,
     }
   }, [positions, candidate, position, candidateId]);
 
+  // Effect to refresh offers when flag is set
+  useEffect(() => {
+    const checkRefresh = () => {
+      const shouldRefresh = localStorage.getItem('refreshOffers');
+      if (shouldRefresh && sessionData.APP_URL && sessionData.token) {
+        localStorage.removeItem('refreshOffers');
+        // Refetch offers
+        fetchOffers();
+      }
+    };
+
+    const interval = setInterval(checkRefresh, 1000); // Check every second
+    return () => clearInterval(interval);
+  }, [sessionData]);
+
+  const fetchOffers = async () => {
+    try {
+      // First fetch applications for candidate names
+      const applicationsResponse = await fetch(
+        `${sessionData.APP_URL}/api/job-applications?type=API&token=${sessionData.token}&sub_institute_id=${sessionData.sub_institute_id}`,
+        {
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+
+      let candidateMap: { [key: number]: string } = {};
+      if (applicationsResponse.ok) {
+        const applicationsResult = await applicationsResponse.json();
+        applicationsResult.data.forEach((app: any) => {
+          const fullName = [app.first_name, app.middle_name, app.last_name].filter(Boolean).join(' ');
+          candidateMap[app.id] = fullName || `Candidate ${app.id}`;
+        });
+      }
+
+      const offersResponse = await fetch(
+        `${sessionData.APP_URL}/api/offers?type=API&token=${sessionData.token}&sub_institute_id=${sessionData.sub_institute_id}`,
+        {
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+
+      if (offersResponse.ok) {
+        const offersResult = await offersResponse.json();
+        const mappedOffers = offersResult.data.map((item: any) => ({
+          id: item.id,
+          candidateId: item.application_id,
+          candidateName: candidateMap[item.application_id] || `Candidate ${item.application_id}`,
+          position: item.position,
+          jobTitle: item.position,
+          salary: item.salary,
+          startDate: item.start_date,
+          status: item.status as 'draft' | 'sent' | 'accepted' | 'rejected' | 'expired',
+          createdAt: new Date(item.created_at).toISOString().split('T')[0],
+          expiresAt: item.expires_at ? new Date(item.expires_at).toISOString().split('T')[0] : '',
+          sentAt: item.sent_at ? new Date(item.sent_at).toISOString().split('T')[0] : undefined,
+          acceptedAt: undefined,
+          rejectedAt: item.rejected_at ? new Date(item.rejected_at).toISOString().split('T')[0] : undefined,
+          offerLetterUrl: item.offer_letter_url,
+          notes: item.notes,
+        }));
+        setOffers(mappedOffers);
+      }
+    } catch (error) {
+      console.warn("Error refreshing offers:", error);
+    }
+  };
+
   useEffect(() => {
     if (!sessionData || !sessionData.APP_URL || !sessionData.token) return;
 
@@ -223,47 +294,7 @@ export default function OfferDashboard({ showHeader = true, candidate, position,
           });
         }
 
-        // Try to fetch real offers data
-        const offersResponse = await fetch(
-          `${sessionData.APP_URL}/api/offers?type=API&token=${sessionData.token}&sub_institute_id=${sessionData.sub_institute_id}`,
-          {
-            headers: {
-              "Content-Type": "application/json",
-            },
-          }
-        );
-
-        if (offersResponse.ok) {
-          const offersResult = await offersResponse.json();
-          const mappedOffers = offersResult.data.map((item: any) => {
-            const createdAt = new Date(item.created_at).toISOString().split('T')[0];
-            const startDate = item.start_date;
-            const expiresAt = item.expires_at ? new Date(item.expires_at).toISOString().split('T')[0] : '';
-            const sentAt = item.sent_at ? new Date(item.sent_at).toISOString().split('T')[0] : undefined;
-            const rejectedAt = item.rejected_at ? new Date(item.rejected_at).toISOString().split('T')[0] : undefined;
-            return {
-              id: item.id,
-              candidateId: item.application_id,
-              candidateName: candidateMap[item.application_id] || `Candidate ${item.application_id}`,
-              position: item.position,
-              jobTitle: item.position,
-              salary: item.salary,
-              startDate,
-              status: item.status as 'draft' | 'sent' | 'accepted' | 'rejected' | 'expired',
-              createdAt,
-              expiresAt,
-              sentAt,
-              acceptedAt: undefined,
-              rejectedAt,
-              offerLetterUrl: item.offer_letter_url,
-              notes: item.notes,
-            };
-          });
-          setOffers(mappedOffers);
-        } else {
-          // No data available
-          setOffers([]);
-        }
+        // Offers will be fetched only after successful send via refreshOffers flag
 
         // Try to fetch templates
         const templatesResponse = await fetch(
@@ -311,12 +342,117 @@ export default function OfferDashboard({ showHeader = true, candidate, position,
     fetchData();
   }, [sessionData]);
 
+  // const createOffer = async () => {
+  //   if (!sessionData) return;
+
+  //   setIsCreatingOffer(true);
+  //   try {
+  //     const response = await fetch(`${sessionData.APP_URL}/api/talent-offers`, {
+  //       method: 'POST',
+  //       headers: {
+  //         'Content-Type': 'application/json',
+  //       },
+  //       body: JSON.stringify({
+  //         type: "API",
+  //         token: sessionData.token,
+  //         sub_institute_id: sessionData.sub_institute_id,
+  //         user_id: sessionData.user_id,
+  //         position: newOffer.position,
+  //         application_id: parseInt(newOffer.candidateId),
+  //         job_id: parseInt(newOffer.jobId),
+  //         salary: newOffer.salary,
+  //         start_date: newOffer.startDate,
+  //         notes: newOffer.notes
+  //       })
+  //     });
+
+  //     if (response.ok) {
+  //       const result = await response.json();
+
+  //       // Fetch additional data for template filling
+  //       const [employeeRes, companyRes, hrRes, templatesRes] = await Promise.all([
+  //         fetch(`${sessionData.APP_URL}/api/job-applications/${newOffer.candidateId}?type=API&token=${sessionData.token}&sub_institute_id=${sessionData.sub_institute_id}`),
+  //         fetch(`${sessionData.APP_URL}/settings/organization_data?type=API&token=${sessionData.token}&sub_institute_id=${sessionData.sub_institute_id}`),
+  //         fetch(`${sessionData.APP_URL}/api/hr?type=API&token=${sessionData.token}&sub_institute_id=${sessionData.sub_institute_id}`),
+  //         fetch(`${sessionData.APP_URL}/api/templates?sub_institute_id=${sessionData.sub_institute_id}`, {
+  //           headers: { "Authorization": `Bearer ${sessionData.token}` }
+  //         })
+  //       ]);
+
+  //       let employeeData = {};
+  //       let companyData = {};
+  //       let hrData = {};
+
+  //       let templateId = null;
+
+  //       if (employeeRes.ok) {
+  //         const emp = await employeeRes.json();
+  //         employeeData = emp.data || {};
+  //       }
+
+  //       if (companyRes.ok) {
+  //         const comp = await companyRes.json();
+  //         companyData = comp.data || {};
+  //       }
+
+  //       if (hrRes.ok) {
+  //         const hr = await hrRes.json();
+  //         hrData = hr.data || {};
+  //       }
+
+
+
+  //       if (templatesRes.ok) {
+  //         const temps = await templatesRes.json();
+  //         const offerTemplate = temps.find((t: any) => t.name.toLowerCase().includes('offer'));
+  //         templateId = offerTemplate?.id || temps[0]?.id; // Use first template if no offer template found
+  //       }
+
+  //       if (templateId) {
+  //         // Prepare offer data for template
+  //         const offerData = {
+  //           candidateId: newOffer.candidateId,
+  //           candidateName: newOffer.candidateName,
+  //           position: newOffer.position,
+  //           salary: newOffer.salary,
+  //           startDate: newOffer.startDate,
+  //           notes: newOffer.notes,
+  //           employeeData,
+  //           companyData,
+  //           hrData,
+  //           offerId: result.data?.id
+  //         };
+
+  //         // Store in localStorage for template dashboard/editor
+  //         localStorage.setItem('offerData', JSON.stringify(offerData));
+  //         console.log('Offer data stored:', offerData);
+
+  //         // Redirect to template dashboard
+  //         router.push(`/content/hr-templates`);
+  //       } else {
+  //         alert('No offer template found. Please create an offer letter template first.');
+  //       }
+
+  //       setIsCreateDialogOpen(false);
+  //       resetNewOfferForm();
+  //     } else {
+  //       alert('Failed to create offer');
+  //     }
+  //   } catch (error) {
+  //     console.error('Error creating offer:', error);
+  //     alert('Error creating offer');
+  //   } finally {
+  //     setIsCreatingOffer(false);
+  //   }
+  // };
+
   const createOffer = async () => {
     if (!sessionData) return;
 
     setIsCreatingOffer(true);
     try {
-      const response = await fetch(`${sessionData.APP_URL}/api/talent-offers`, {
+      // First create the offer in database
+      const createResponse = await fetch(`${sessionData.APP_URL}/api/talent-offers`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -335,31 +471,100 @@ export default function OfferDashboard({ showHeader = true, candidate, position,
         })
       });
 
-      if (response.ok) {
-        const result = await response.json();
-        alert('Offer created successfully!');
+      if (!createResponse.ok) {
+        alert('Failed to create offer. Please try again.');
+        return;
+      }
 
-        // Add to local state
-        const newOfferWithId: Offer = {
-          id: result.data?.id || Date.now(),
-          candidateId: parseInt(newOffer.candidateId),
+      const createResult = await createResponse.json();
+      const offerId = createResult.data?.id;
+
+      // Add the new offer to local state immediately
+      const newOfferData = {
+        id: offerId,
+        candidateId: parseInt(newOffer.candidateId),
+        candidateName: newOffer.candidateName,
+        position: newOffer.position,
+        jobTitle: newOffer.position,
+        salary: newOffer.salary,
+        startDate: newOffer.startDate,
+        status: 'draft' as const,
+        createdAt: new Date().toISOString().split('T')[0],
+        expiresAt: '',
+        notes: newOffer.notes
+      };
+      setOffers(prev => [...prev, newOfferData]);
+
+      // Fetch additional data for template filling
+      console.log('APP_URL:', sessionData.APP_URL);
+      const [employeeRes, companyRes, hrRes, templatesRes] = await Promise.all([
+        fetch(`${sessionData.APP_URL}/api/job-applications/${newOffer.candidateId}?type=API&token=${sessionData.token}&sub_institute_id=${sessionData.sub_institute_id}`),
+        fetch(`${sessionData.APP_URL}/settings/organization_data?type=API&token=${sessionData.token}&sub_institute_id=${sessionData.sub_institute_id}`),
+        fetch(`${sessionData.APP_URL}/api/hr?type=API&token=${sessionData.token}&sub_institute_id=${sessionData.sub_institute_id}`),
+        fetch(`${sessionData.APP_URL}/api/templates?sub_institute_id=${sessionData.sub_institute_id}`, {
+          headers: { "Authorization": `Bearer ${sessionData.token}` }
+        })
+      ]);
+
+      let employeeData = {};
+      let companyData = {};
+      let hrData = {};
+
+      let templateId = null;
+
+      if (employeeRes.ok) {
+        const emp = await employeeRes.json();
+        employeeData = emp.data || {};
+      }
+
+      if (companyRes.ok) {
+        const comp = await companyRes.json();
+        companyData = comp.org_data && comp.org_data.length > 0 ? comp.org_data[0] : {};
+        console.log('Company data fetched:', companyData);
+      } else {
+        console.error('Failed to fetch company data:', companyRes.status, companyRes.statusText);
+      }
+
+      if (hrRes.ok) {
+        const hr = await hrRes.json();
+        hrData = hr.data || {};
+      }
+
+      if (templatesRes.ok) {
+        const temps = await templatesRes.json();
+        const offerTemplate = temps.find((t: any) => t.name.toLowerCase().includes('offer'));
+        templateId = offerTemplate?.id || temps[0]?.id; // Use first template if no offer template found
+      }
+
+      if (templateId) {
+        // Prepare offer data for template
+        const offerData = {
+          candidateId: newOffer.candidateId,
           candidateName: newOffer.candidateName,
           position: newOffer.position,
-          jobTitle: newOffer.jobTitle,
+          jobId: newOffer.jobId,
           salary: newOffer.salary,
           startDate: newOffer.startDate,
-          status: 'draft',
-          createdAt: new Date().toISOString().split('T')[0],
-          expiresAt: '',
-          notes: newOffer.notes
+          notes: newOffer.notes,
+          employeeData,
+          companyData,
+          hrData,
+          offerId: offerId // Now includes the created offer ID
         };
-        setOffers(prev => [...prev, newOfferWithId]);
 
-        setIsCreateDialogOpen(false);
-        resetNewOfferForm();
+        // Store in localStorage for template dashboard/editor
+        localStorage.setItem('offerData', JSON.stringify(offerData));
+        console.log('Offer data stored:', offerData);
+        console.log('Company data in offerData:', offerData.companyData);
+
+        // Redirect to template dashboard
+        router.push(`/content/hr-templates`);
       } else {
-        alert('Failed to create offer');
+        alert('No offer template found. Please create an offer letter template first.');
       }
+
+      setIsCreateDialogOpen(false);
+      resetNewOfferForm();
     } catch (error) {
       console.error('Error creating offer:', error);
       alert('Error creating offer');
@@ -399,38 +604,38 @@ export default function OfferDashboard({ showHeader = true, candidate, position,
     }
   };
 
-  const sendOffer = async (offer: Offer) => {
-    if (!sessionData) return;
+  // const sendOffer = async (offer: Offer) => {
+  //   if (!sessionData) return;
 
-    try {
-      const response = await fetch(`${sessionData.APP_URL}/api/talent-offers/${offer.id}/send`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          type: "API",
-          token: sessionData.token,
-          candidateEmail: `${offer.candidateName.toLowerCase().replace(' ', '.')}@example.com`,
-          offerDetails: offer
-        })
-      });
+  //   try {
+  //     const response = await fetch(`${sessionData.APP_URL}/api/talent-offers/${offer.id}/send`, {
+  //       method: 'POST',
+  //       headers: {
+  //         'Content-Type': 'application/json',
+  //       },
+  //       body: JSON.stringify({
+  //         type: "API",
+  //         token: sessionData.token,
+  //         candidateEmail: `${offer.candidateName.toLowerCase().replace(' ', '.')}@example.com`,
+  //         offerDetails: offer
+  //       })
+  //     });
 
-      if (response.ok) {
-        updateOffer(offer.id, {
-          status: 'sent',
-          sentAt: new Date().toISOString().split('T')[0],
-          expiresAt: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000).toISOString().split('T')[0] // 14 days from now
-        });
-        alert('Offer sent successfully!');
-      } else {
-        alert('Failed to send offer');
-      }
-    } catch (error) {
-      console.error('Error sending offer:', error);
-      alert('Error sending offer');
-    }
-  };
+  //     if (response.ok) {
+  //       updateOffer(offer.id, {
+  //         status: 'sent',
+  //         sentAt: new Date().toISOString().split('T')[0],
+  //         expiresAt: new Date(Date.now() + 14 * 24 * 60 * 60 * 1000).toISOString().split('T')[0] // 14 days from now
+  //       });
+  //       alert('Offer sent successfully!');
+  //     } else {
+  //       alert('Failed to send offer');
+  //     }
+  //   } catch (error) {
+  //     console.error('Error sending offer:', error);
+  //     alert('Error sending offer');
+  //   }
+  // };
 
   const rejectOffer = async (offer: Offer) => {
     if (!sessionData) return;
@@ -522,88 +727,88 @@ export default function OfferDashboard({ showHeader = true, candidate, position,
     }
 
     // Fallback: Generate HTML template if no URL is available
-    const htmlContent = `
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Offer Letter - ${offer.candidateName}</title>
-    <style>
-        body { font-family: Arial, sans-serif; margin: 40px; line-height: 1.6; }
-        .header { text-align: center; margin-bottom: 30px; }
-        .date { text-align: right; margin-bottom: 20px; }
-        .address { margin-bottom: 20px; }
-        .salutation { margin-bottom: 20px; }
-        .content { margin-bottom: 20px; }
-        .closing { margin-top: 30px; }
-        .signature { margin-top: 40px; }
-    </style>
-</head>
-<body>
-    <div class="header">
-        <h1>[Company Name]</h1>
-        <p>[Company Address]</p>
-        <p>[City, State, ZIP Code]</p>
-        <p>[Phone] | [Email]</p>
-    </div>
+//     const htmlContent = `
+// <!DOCTYPE html>
+// <html>
+// <head>
+//     <title>Offer Letter - ${offer.candidateName}</title>
+//     <style>
+//         body { font-family: Arial, sans-serif; margin: 40px; line-height: 1.6; }
+//         .header { text-align: center; margin-bottom: 30px; }
+//         .date { text-align: right; margin-bottom: 20px; }
+//         .address { margin-bottom: 20px; }
+//         .salutation { margin-bottom: 20px; }
+//         .content { margin-bottom: 20px; }
+//         .closing { margin-top: 30px; }
+//         .signature { margin-top: 40px; }
+//     </style>
+// </head>
+// <body>
+//     <div class="header">
+//         <h1>[Company Name]</h1>
+//         <p>[Company Address]</p>
+//         <p>[City, State, ZIP Code]</p>
+//         <p>[Phone] | [Email]</p>
+//     </div>
 
-    <div class="date">
-        ${new Date().toLocaleDateString()}
-    </div>
+//     <div class="date">
+//         ${new Date().toLocaleDateString()}
+//     </div>
 
-    <div class="address">
-        ${offer.candidateName}<br>
-        [Candidate Address]<br>
-        [City, State, ZIP Code]
-    </div>
+//     <div class="address">
+//         ${offer.candidateName}<br>
+//         [Candidate Address]<br>
+//         [City, State, ZIP Code]
+//     </div>
 
-    <div class="salutation">
-        Dear ${offer.candidateName},
-    </div>
+//     <div class="salutation">
+//         Dear ${offer.candidateName},
+//     </div>
 
-    <div class="content">
-        <p>We are pleased to offer you the position of <strong>${offer.position}</strong> at [Company Name]. This offer is contingent upon satisfactory completion of background checks and reference verification.</p>
+//     <div class="content">
+//         <p>We are pleased to offer you the position of <strong>${offer.position}</strong> at [Company Name]. This offer is contingent upon satisfactory completion of background checks and reference verification.</p>
 
-        <h3>Position Details:</h3>
-        <ul>
-            <li><strong>Job Title:</strong> ${offer.position}</li>
-            <li><strong>Start Date:</strong> ${offer.startDate}</li>
-            <li><strong>Compensation:</strong> ${offer.salary}</li>
-            <li><strong>Location:</strong> [Location]</li>
-        </ul>
+//         <h3>Position Details:</h3>
+//         <ul>
+//             <li><strong>Job Title:</strong> ${offer.position}</li>
+//             <li><strong>Start Date:</strong> ${offer.startDate}</li>
+//             <li><strong>Compensation:</strong> ${offer.salary}</li>
+//             <li><strong>Location:</strong> [Location]</li>
+//         </ul>
 
-        <h3>Benefits:</h3>
-        <ul>
-            <li>Health insurance</li>
-            <li>Paid time off</li>
-            <li>Professional development allowance</li>
-        </ul>
+//         <h3>Benefits:</h3>
+//         <ul>
+//             <li>Health insurance</li>
+//             <li>Paid time off</li>
+//             <li>Professional development allowance</li>
+//         </ul>
 
-        <p>Please review this offer and let us know your decision by ${offer.expiresAt}.</p>
+//         <p>Please review this offer and let us know your decision by ${offer.expiresAt}.</p>
 
-        <p>If you have any questions, please contact us at [Contact Information].</p>
+//         <p>If you have any questions, please contact us at [Contact Information].</p>
 
-        <p>We look forward to welcoming you to the team!</p>
-    </div>
+//         <p>We look forward to welcoming you to the team!</p>
+//     </div>
 
-    <div class="closing">
-        Sincerely,<br><br>
+//     <div class="closing">
+//         Sincerely,<br><br>
 
-        [Your Name]<br>
-        [Your Position]<br>
-        [Company Name]<br>
-        [Contact Information]
-    </div>
+//         [Your Name]<br>
+//         [Your Position]<br>
+//         [Company Name]<br>
+//         [Contact Information]
+//     </div>
 
-    <div class="signature" style="border-top: 1px solid #000; width: 200px; margin-top: 20px; padding-top: 10px;">
-        Signature
-    </div>
-</body>
-</html>
-    `;
+//     <div class="signature" style="border-top: 1px solid #000; width: 200px; margin-top: 20px; padding-top: 10px;">
+//         Signature
+//     </div>
+// </body>
+// </html>
+//     `;
 
     const newWindow = window.open('', '_blank');
     if (newWindow) {
-      newWindow.document.write(htmlContent);
+      // newWindow.document.write(htmlContent);
       newWindow.document.close();
       newWindow.print();
     }
@@ -858,10 +1063,10 @@ export default function OfferDashboard({ showHeader = true, candidate, position,
                 </div>
 
                 <div className="flex flex-col sm:flex-row justify-end gap-2" id="tour-draft-actions">
-                  <Button variant="outline" size="sm" className="w-full sm:w-auto" onClick={() => sendOffer(offer)}  id="tour-send-offer">
+                  {/* <Button variant="outline" size="sm" className="w-full sm:w-auto" onClick={() => sendOffer(offer)}  id="tour-send-offer">
                     <Send className="w-4 h-4 mr-2" />
                     Send
-                  </Button>
+                  </Button> */}
                   <Button variant="destructive" size="sm" className="w-full sm:w-auto" onClick={() => rejectOffer(offer)}>
                     <X className="w-4 h-4 mr-2" />
                     Reject

--- a/src/app/content/hr-templates/Component/Dashboard.tsx
+++ b/src/app/content/hr-templates/Component/Dashboard.tsx
@@ -24,6 +24,7 @@ export default function DashboardTemplatesPage() {
     const router = useRouter();
     const [templates, setTemplates] = useState<ApiTemplate[]>([]);
     const [sessionData, setSessionData] = useState<SessionData>({});
+    const [offerData, setOfferData] = useState<any>(null);
 
     useEffect(() => {
         if (typeof window !== "undefined") {
@@ -31,6 +32,14 @@ export default function DashboardTemplatesPage() {
             if (userData) {
                 const { APP_URL, token, sub_institute_id } = JSON.parse(userData);
                 setSessionData({ url: APP_URL, token, sub_institute_id });
+            }
+
+            // Load offer data if present
+            const storedOfferData = localStorage.getItem("offerData");
+            if (storedOfferData) {
+                const data = JSON.parse(storedOfferData);
+                setOfferData(data);
+                console.log('Offer data loaded in dashboard:', data);
             }
         }
     }, []);
@@ -81,7 +90,9 @@ export default function DashboardTemplatesPage() {
             <div className="flex justify-between items-center mb-8">
                 <div>
                     <h1 className="text-3xl font-bold tracking-tight">Templates </h1>
-                    <p className="text-muted-foreground mt-1">Manage your HR document templates..</p>
+                    <p className="text-muted-foreground mt-1">
+                        {offerData ? `Creating offer letter for ${offerData.candidateName} - ${offerData.position}` : 'Manage your HR document templates..'}
+                    </p>
                 </div>
                 <button
                     onClick={() => router.push(`/content/hr-templates/editor/${uuidv4()}`)}
@@ -105,19 +116,27 @@ export default function DashboardTemplatesPage() {
                 </div>
             ) : (
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                    {templates.map((template) => (
-                        <div key={template.id} className="bg-white border rounded-lg hover:shadow-md transition-shadow overflow-hidden">
+                    {templates.map((template) => {
+                        const isOfferTemplate = template.name.toLowerCase().includes('offer') || template.name.toLowerCase().includes('letter');
+                        return (
+                        <div key={template.id} className={`bg-white border rounded-lg hover:shadow-md transition-shadow overflow-hidden ${offerData && isOfferTemplate ? 'ring-2 ring-green-500 ring-opacity-50' : ''}`}>
                             <div className="p-6">
-                                <h3 className="font-medium text-lg truncate mb-1" title={template.name}>{template.name}</h3>
+                                <h3 className="font-medium text-lg truncate mb-1" title={template.name}>
+                                    {template.name}
+                                    {offerData && isOfferTemplate && <span className="ml-2 text-xs bg-green-100 text-green-800 px-2 py-1 rounded-full">Recommended</span>}
+                                </h3>
                                 <span className="text-xs text-muted-foreground">ID: {template.id}</span>
 
                                 <div className="flex space-x-2 mt-4">
-                                    <Link
-                                        href={`/content/hr-templates/editor/${template.id}`}
+                                    <Button
+                                        onClick={() => {
+                                            console.log('Selected template:', template.id, 'with offer data:', offerData);
+                                            router.push(`/content/hr-templates/editor/${template.id}`);
+                                        }}
                                         className="flex-1 inline-flex items-center justify-center rounded-md font-medium h-9 px-3 text-sm bg-secondary text-secondary-foreground hover:bg-secondary/80 transition-colors"
                                     >
                                         <Edit className="w-4 h-4 mr-2" /> Edit
-                                    </Link>
+                                    </Button>
                                     <Button
                                         variant="outline"
                                         size="icon"
@@ -129,7 +148,8 @@ export default function DashboardTemplatesPage() {
                                 </div>
                             </div>
                         </div>
-                    ))}
+                        );
+                    })}
                 </div>
             )}
         </div>

--- a/src/app/content/hr-templates/editor/[templateId]/Component/Template.tsx
+++ b/src/app/content/hr-templates/editor/[templateId]/Component/Template.tsx
@@ -34,6 +34,7 @@ export default function EditorPage({ params }: { params: Promise<{ templateId: s
     const [toolboxTab, setToolboxTab] = useState<string | null>(null);
     const [activeTool, setActiveTool] = useState<WhiteboardTool>('select');
     const [isFloatingToolbarVisible, setIsFloatingToolbarVisible] = useState(true);
+    const [offerData, setOfferData] = useState<any>(null);
 
     const handleSetToolboxTab = (tab: string | null) => {
         setToolboxTab(tab);
@@ -43,6 +44,62 @@ export default function EditorPage({ params }: { params: Promise<{ templateId: s
     };
     const [sessionData, setSessionData] = useState<SessionData>({});
 
+    // Function to replace placeholders in template content
+    const replacePlaceholders = (content: any, offerData: any) => {
+        if (!offerData) return content;
+
+        const replacements = {
+            '{{employee_name}}': offerData.candidateName || '',
+            '{{candidate_name}}': offerData.candidateName || '',
+            '{{designation}}': offerData.position || '',
+            '{{position}}': offerData.position || '',
+            '{{joining_date}}': offerData.startDate || '',
+            '{{start_date}}': offerData.startDate || '',
+            '{{salary_amount}}': offerData.salary || '',
+            '{{salary}}': offerData.salary || '',
+            '{{company_name}}': offerData.companyData?.legal_name || offerData.companyData?.name || '',
+            '{{company_address}}': offerData.companyData?.registered_address || offerData.companyData?.address || '',
+            '{{company_email}}': offerData.companyData?.email || '',
+            '{{company_phone}}': offerData.companyData?.mobile_no || offerData.companyData?.phone || '',
+            '{{company_website}}': offerData.companyData?.website || '',
+            '{{company_logo}}': offerData.companyData?.logo || '',
+            '{{company_cin}}': offerData.companyData?.cin || '',
+            '{{company_gstin}}': offerData.companyData?.gstin || '',
+            '{{company_pan}}': offerData.companyData?.pan || '',
+            '{{department_name}}': offerData.employeeData?.department_name || '',
+            '{{candidate_email}}': offerData.employeeData?.email || '',
+            '{{candidate_mobile}}': offerData.employeeData?.mobile || '',
+            '{{hr_name}}': offerData.hrData?.name || '',
+            '{{hr_designation}}': offerData.hrData?.designation || '',
+            '{{hr_email}}': offerData.hrData?.email || '',
+            '{{offer_date}}': new Date().toLocaleDateString(),
+            '{{reporting_manager}}': offerData.companyData?.reporting_manager || 'Manager Name',
+            '{{probation_period}}': '3 months',
+            '{{notes}}': offerData.notes || ''
+        };
+
+        const traverseAndReplace = (obj: any): any => {
+            if (typeof obj === 'string') {
+                let replaced = obj;
+                Object.entries(replacements).forEach(([placeholder, value]) => {
+                    replaced = replaced.replace(new RegExp(placeholder, 'g'), value);
+                });
+                return replaced;
+            } else if (Array.isArray(obj)) {
+                return obj.map(traverseAndReplace);
+            } else if (obj && typeof obj === 'object') {
+                const newObj: any = {};
+                for (const key in obj) {
+                    newObj[key] = traverseAndReplace(obj[key]);
+                }
+                return newObj;
+            }
+            return obj;
+        };
+
+        return traverseAndReplace(content);
+    };
+
     useEffect(() => {
         setMounted(true);
         if (typeof window !== "undefined") {
@@ -50,6 +107,13 @@ export default function EditorPage({ params }: { params: Promise<{ templateId: s
             if (userData) {
                 const { APP_URL, token, sub_institute_id } = JSON.parse(userData);
                 setSessionData({ url: APP_URL, token, sub_institute_id });
+            }
+
+            // Load offer data if present
+            const storedOfferData = localStorage.getItem("offerData");
+            if (storedOfferData) {
+                setOfferData(JSON.parse(storedOfferData));
+                localStorage.removeItem("offerData"); // Clear after loading
             }
         }
     }, []);
@@ -61,7 +125,7 @@ export default function EditorPage({ params }: { params: Promise<{ templateId: s
     return (
         <div className="flex flex-col h-screen overflow-hidden">
             <Editor resolver={{ TextBlock, ImageBlock, ContainerBlock, A4PageBlock, ButtonBlock, DividerBlock, GridBlock, ShapeBlock, TableBlock, DrawingBlock, LineBlock }}>
-                <Topbar templateId={templateId} />
+                <Topbar templateId={templateId} offerData={offerData} />
 
                 <div className="flex flex-1 overflow-hidden relative">
                     <div className="z-20 flex flex-col border-r border-border bg-white h-full relative" style={{ width: toolboxTab ? "368px" : "80px", transition: "width 0.3s ease-in-out" }}>
@@ -91,7 +155,7 @@ export default function EditorPage({ params }: { params: Promise<{ templateId: s
                             />
                         )}
                         <EditorCanvas activeTool={activeTool}>
-                            <FrameLoader templateId={templateId} sessionData={sessionData} />
+                            <FrameLoader templateId={templateId} sessionData={sessionData} offerData={offerData} replacePlaceholders={replacePlaceholders} />
                         </EditorCanvas>
                     </div>
                 </div>
@@ -100,7 +164,7 @@ export default function EditorPage({ params }: { params: Promise<{ templateId: s
     );
 }
 
-function FrameLoader({ templateId, sessionData }: { templateId: string; sessionData: SessionData }) {
+function FrameLoader({ templateId, sessionData, offerData, replacePlaceholders }: { templateId: string; sessionData: SessionData; offerData: any; replacePlaceholders: (content: any, data: any) => any }) {
     const { actions } = useEditor();
     const [loaded, setLoaded] = useState(false);
 
@@ -152,8 +216,12 @@ function FrameLoader({ templateId, sessionData }: { templateId: string; sessionD
 
                 if (response.ok && isMounted) {
                     const template = await response.json();
-                    const content = template.content;
+                    let content = template.content;
                     if (content) {
+                        // Replace placeholders if offerData exists
+                        if (offerData) {
+                            content = replacePlaceholders(content, offerData);
+                        }
                         timeoutId = setTimeout(() => {
                             if (isMounted) {
                                 try {

--- a/src/components/hr-template/editor/Topbar.tsx
+++ b/src/components/hr-template/editor/Topbar.tsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from "react";
 import { useEditor } from "@craftjs/core";
 import { useRouter } from "next/navigation";
 import { Button } from "../../ui/button";
-import { Save, Download, Trash2, FilePlus, ArrowLeft, Loader2, ChevronDown, FileText, Image as ImageIcon, Undo2, Redo2 } from "lucide-react";
+import { Save, Download, Trash2, FilePlus, ArrowLeft, Loader2, ChevronDown, FileText, Image as ImageIcon, Undo2, Redo2, Send } from "lucide-react";
 import { v4 as uuidv4 } from "uuid";
 import html2canvas from "html2canvas-pro";
 import jsPDF from "jspdf";
@@ -16,10 +16,12 @@ interface SessionData {
     token?: string;
     sub_institute_id?: string;
     org_type?: string;
+    user_id?: number;
+    id?: number;
 }
 
 
-export const Topbar = ({ templateId }: { templateId?: string }) => {
+export const Topbar = ({ templateId, offerData }: { templateId?: string; offerData?: any }) => {
     const router = useRouter();
     const { actions, query } = useEditor();
     const [currentId, setCurrentId] = React.useState(templateId || uuidv4());
@@ -29,6 +31,7 @@ export const Topbar = ({ templateId }: { templateId?: string }) => {
     const [tempName, setTempName] = useState("");
     const [isEditing, setIsEditing] = useState(false);
     const [isExporting, setIsExporting] = useState(false);
+    const [isSending, setIsSending] = useState(false);
 
     // ── Reactive canvas-level undo/redo ──
     // Sync with Craft.js history on every state change (zero polling, instant response)
@@ -109,8 +112,8 @@ export const Topbar = ({ templateId }: { templateId?: string }) => {
         if (typeof window !== "undefined") {
             const userData = localStorage.getItem("userData");
             if (userData) {
-                const { APP_URL, token, sub_institute_id, org_type } = JSON.parse(userData);
-                setSessionData({ url: APP_URL, token, sub_institute_id, org_type });
+                const { APP_URL, token, sub_institute_id, org_type, user_id } = JSON.parse(userData);
+                setSessionData({ url: APP_URL, token, sub_institute_id, org_type, user_id });
             }
         }
     }, []);
@@ -254,6 +257,48 @@ export const Topbar = ({ templateId }: { templateId?: string }) => {
         router.push("/content/hr-templates");
     };
 
+    const handleSendOffer = async () => {
+        if (!offerData || !sessionData.url || !sessionData.token) return;
+
+        setIsSending(true);
+        try {
+            // Mark the offer as sent (backend will handle email sending)
+            const body: any = {
+                type: 'API',
+                token: sessionData.token,
+                sub_institute_id: sessionData.sub_institute_id,
+                user_id: sessionData.user_id,
+                application_id: offerData.candidateId,
+                job_id: offerData.jobId,
+                position: offerData.position,
+                candidateEmail: offerData.employeeData?.email || `${offerData.candidateName.toLowerCase().replace(' ', '.')}@example.com`,
+                offerDetails: offerData
+            };
+            const sendResponse = await fetch(`${sessionData.url}/api/talent-offers`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(body)
+            });
+
+            if (sendResponse.ok) {
+                alert('Offer sent successfully!');
+                // Clear offer data and trigger offers refresh
+                localStorage.removeItem('offerData');
+                localStorage.setItem('refreshOffers', 'true');
+                router.push('/content/Telent-management/ManagerHub');
+            } else {
+                alert('Failed to send offer. Please try again.');
+            }
+        } catch (error) {
+            console.error('Error sending offer:', error);
+            alert('Error sending offer. Please try again.');
+        } finally {
+            setIsSending(false);
+        }
+    };
+
     const handleExport = async (format: "pdf" | "png" | "jpg" | "docx") => {
         const element = document.getElementById("editor-canvas");
         if (!element) return;
@@ -389,6 +434,11 @@ export const Topbar = ({ templateId }: { templateId?: string }) => {
                         </DropdownMenuItem>
                     </DropdownMenuContent>
                 </DropdownMenu>
+                {offerData && (
+                    <Button size="sm" disabled={isSending} onClick={() => handleSendOffer()} className="bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white shadow-[0_4px_14px_0_rgba(16,185,129,0.39)] hover:shadow-[0_6px_20px_rgba(16,185,129,0.23)] hover:-translate-y-[1px] rounded-lg transition-all duration-200 border-0">
+                        {isSending ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : <Send className="w-4 h-4 mr-2" />} Send Offer
+                    </Button>
+                )}
                 <Button size="sm" onClick={isEditing ? handleUpdate : handleSaveClick} className="bg-gradient-to-r from-sky-500 to-blue-600 hover:from-sky-600 hover:to-blue-700 text-white shadow-[0_4px_14px_0_rgba(14,165,233,0.39)] hover:shadow-[0_6px_20px_rgba(14,165,233,0.23)] hover:-translate-y-[1px] rounded-lg transition-all duration-200 border-0">
                     {isEditing ? <><Save className="w-4 h-4 mr-2" /> save </> : <><Save className="w-4 h-4 mr-2" /> Save</>}
                 </Button>


### PR DESCRIPTION
Implement end-to-end offer letter automation by integrating candidate and company data into the template editor.

- Add recursive placeholder replacement engine in the template editor to support dynamic fields like {{candidate_name}} and {{salary}}.
- Implement automated offer sending functionality via the template topbar, triggering backend email dispatch.
- Update Offer Dashboard to support real-time data refreshing using localStorage signaling.
- Enhance HR Template Dashboard with "Recommended" indicators for offer-related templates when active offer data is present.
- Add data mapping for candidate and application details to ensure accurate template population.