### PR TITLE
refactor(api): reduce max_tokens for question generation

### DIFF
--- a/src/app/api/generate-questions/route.ts
+++ b/src/app/api/generate-questions/route.ts
@@ -192,7 +192,7 @@ OUTPUT FORMAT (JSON ONLY)
                 Ensure the final output strictly follows this structure.`,
             },
             { role: "user", content: JSON.stringify(prompt, null, 2) }],
-          max_tokens: 8000,
+          max_tokens: 1500,
           temperature: 0.0,
           top_p: 0.0,
           top_k: 1,


### PR DESCRIPTION
Decrease the `max_tokens` limit from 8000 to 1500 in the question generation route to optimize response latency and prevent excessive token consumption.