### PR TITLE
refactor(user): update job role handling and working days logic

### DIFF
--- a/src/app/content/Dashboard/UserProfile.css
+++ b/src/app/content/Dashboard/UserProfile.css
@@ -1522,13 +1522,27 @@ box-shadow : none !important;
     cursor: pointer;
 }
 
+.working-day-label input[type="checkbox"] {
+    width: 14px;
+    height: 14px;
+    cursor: pointer;
+    border: rounded;
+    margin-left:1px;
+    padding:1px;
+}
+
 @media (max-width: 768px) {
     .working-days-container {
         gap: 0.75rem;
     }
-    
+
     .working-day-label {
         min-width: 50px;
+    }
+
+    .working-day-label input[type="checkbox"] {
+        width: 12px;
+        height: 12px;
     }
 }
 

--- a/src/app/content/task/taskManagement.tsx
+++ b/src/app/content/task/taskManagement.tsx
@@ -813,7 +813,7 @@ const TaskManagement = () => {
           'Content-Type': 'application/json'
         },
         body: JSON.stringify({
-          prompt: prompt + ` for jobrole ${selJobroleText}, Generate a single JSON object with the following fields: task_description, repeat_once_in_every, repeat_until_date (format: YYYY-MM-DD), observation_point, kras (only 1), kpis(only 1), monitoring_point, task_type(High,Medium,Low), skill_required return in array and select from givien list ${skillsData}. Return as a single-element array containing only this object.`
+          prompt: prompt + ` for jobrole ${selJobroleText}, Generate a single JSON object with the following fields: task_description, repeat_once_in_every, repeat_until_date (format: YYYY-MM-DD), observation_point, kras (only 1), kpis(only 1), monitoring_point, task_type(High,Medium,Low), skill_required return in array and select only the most relevant 1-3 skills from given list ${skillsData}. Return as a single-element array containing only this object.`
         })
       })
 
@@ -834,8 +834,10 @@ const TaskManagement = () => {
         };
         setRepeatDays(repeatMapping[geminiData.repeat_once_in_every] || "1");
 
-        const formattedDate = formatDateForInput(geminiData.repeat_until_date);
-        setRepeatUntil(formattedDate);
+        const oneYearFromNow = new Date();
+        oneYearFromNow.setFullYear(oneYearFromNow.getFullYear() + 1);
+        const defaultDate = oneYearFromNow.toISOString().split('T')[0];
+        setRepeatUntil(defaultDate);
 
         setObservationPoint(geminiData.observation_point);
         setKras(geminiData.kras);
@@ -843,7 +845,7 @@ const TaskManagement = () => {
         const selectedSkillIds = geminiData.skill_required.map((skillName: string) => {
           const skillObj = skillList.find(s => s.skill === skillName);
           return skillObj ? skillObj.skill_id.toString() : '';
-        }).filter(id => id);
+        }).filter(id => id).slice(0, 3); // Limit to 3 skills
         setSelSkill(selectedSkillIds);
         setTaskType(geminiData.task_type || "Medium");
       } else {

--- a/src/app/content/user/components/EmployeeTable.jsx
+++ b/src/app/content/user/components/EmployeeTable.jsx
@@ -345,11 +345,11 @@ const EmployeeTable = ({
     {
       name: (
         <div>
-          <div>Status</div>
+          <div>Job Role</div>
           <input
             type="text"
             placeholder="Search..."
-            onChange={(e) => handleColumnFilter("status", e.target.value)}
+            onChange={(e) => handleColumnFilter("jobRole", e.target.value)}
             style={{
               width: "100%",
               padding: "4px",
@@ -360,12 +360,11 @@ const EmployeeTable = ({
           />
         </div>
       ),
-      selector: row => row.status,
+      selector: row => row.jobRole,
       sortable: true,
       cell: (row) => (
-        <div className="flex items-center space-x-2 text-sm text-foreground">
-          <span className={`inline-block w-2 h-2 rounded-full ${getStatusColor(row.status)}`} />
-          <span>{row.status}</span>
+        <div className="text-sm text-foreground">
+          {row.jobRole}
         </div>
       ),
       omit: window.innerWidth < 1024 // Hide on mobile

--- a/src/app/content/user/index.jsx
+++ b/src/app/content/user/index.jsx
@@ -142,7 +142,7 @@ const EmployeeDirectory = () => {
         email: item.email || 'N/A',
         mobile: item.mobile || 'N/A',
         department_name: item.department_name || 'N/A',
-        jobRole: item.designation || 'N/A',
+        jobRole: item.jobrole || 'N/A',
         address: item.address || 'N/A',
         image: item.image?.trim()
           ? item.image

--- a/src/components/users/personalDetails.tsx
+++ b/src/components/users/personalDetails.tsx
@@ -65,13 +65,16 @@ const PersonalDetails: React.FC<userDetailsprops> = ({
       reporting_method: userDetails?.reporting_method || "",
     },
     attendance: {
-      working_days: userDetails?.working_days || [
-        "Mon",
-        "Tue",
-        "Wed",
-        "Thu",
-        "Fri",
-      ],
+      working_days: (() => {
+        const days = [];
+        if (userDetails?.monday === 1 || userDetails?.monday === "1") days.push("Mon");
+        if (userDetails?.tuesday === 1 || userDetails?.tuesday === "1") days.push("Tue");
+        if (userDetails?.wednesday === 1 || userDetails?.wednesday === "1") days.push("Wed");
+        if (userDetails?.thursday === 1 || userDetails?.thursday === "1") days.push("Thu");
+        if (userDetails?.friday === 1 || userDetails?.friday === "1") days.push("Fri");
+        if (userDetails?.saturday === 1 || userDetails?.saturday === "1") days.push("Sat");
+        return days.length > 0 ? days : ["Mon", "Tue", "Wed", "Thu", "Fri"];
+      })(),
       monday_in: userDetails?.monday_in_date || "",
       monday_out: userDetails?.monday_out_date || "",
       tuesday_in: userDetails?.tuesday_in_date || "",


### PR DESCRIPTION
- Update `EmployeeTable` to filter and display `jobRole` instead of `status`.
- Fix mapping of `jobRole` in `EmployeeDirectory` to use `item.jobrole`.
- Implement dynamic working days calculation in `PersonalDetails` based on individual day flags.
- Improve `TaskManagement` AI prompt to limit skill selection to 1-3 relevant skills and set a default one-year expiration date.
- Refine CSS for working day checkbox styling and responsiveness.