### PR TITLE
feat(task): update task allocation mapping and default repeat date

### DIFF
--- a/src/app/content/task/components/ProgressDashboard.jsx
+++ b/src/app/content/task/components/ProgressDashboard.jsx
@@ -330,7 +330,11 @@ const ProgressDashboard = () => {
       // Append all task data
       Object.keys(currentTask).forEach(key => {
         if (key !== 'task_attachment') {
-          formData.append(key, currentTask[key]);
+          if (key === 'task_allocated') {
+            formData.append('manageby', currentTask[key]);
+          } else {
+            formData.append(key, currentTask[key]);
+          }
         }
       });
 
@@ -779,23 +783,23 @@ const ProgressDashboard = () => {
               {/* Task Details Section */}
               <div className="border rounded-lg p-4">
                 <h3 className="text-lg font-semibold mb-4 text-black-700">Task Details :</h3>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  <div>
-                    <Input
-                      label="Task Title"
-                      value={currentTask.task_title}
-                      onChange={(e) => handleInputChange('task_title', e.target.value)}
-                      required
-                    />
-                  </div>
-                  <div>
-                    <Input
-                      label="Observer"
-                      value={currentTask.ALLOCATOR}
-                      disabled
-                    />
-                  </div>
-                </div>
+                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                   <div>
+                     <Input
+                       label="Task Title"
+                       value={currentTask.task_title}
+                       onChange={(e) => handleInputChange('task_title', e.target.value)}
+                       required
+                     />
+                   </div>
+                   <div>
+                     <Input
+                       label="Observer"
+                       value={employees.find(emp => emp.id == currentTask.task_allocated)?.first_name + ' ' + employees.find(emp => emp.id == currentTask.task_allocated)?.last_name || currentTask.ALLOCATOR}
+                       disabled
+                     />
+                   </div>
+                 </div>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-4">
                   <div>
                     <div className="space-y-2">

--- a/src/app/content/task/taskManagement.tsx
+++ b/src/app/content/task/taskManagement.tsx
@@ -834,9 +834,9 @@ const TaskManagement = () => {
         };
         setRepeatDays(repeatMapping[geminiData.repeat_once_in_every] || "1");
 
-        const oneYearFromNow = new Date();
-        oneYearFromNow.setFullYear(oneYearFromNow.getFullYear() + 1);
-        const defaultDate = oneYearFromNow.toISOString().split('T')[0];
+        const nextDay = new Date();
+        nextDay.setDate(nextDay.getDate() + 1);
+        const defaultDate = nextDay.toISOString().split('T')[0];
         setRepeatUntil(defaultDate);
 
         setObservationPoint(geminiData.observation_point);


### PR DESCRIPTION
- Map `task_allocated` field to `manageby` in `ProgressDashboard` form data
- Display observer name by looking up employee details from `task_allocated` ID
- Change default `repeat_until` date from one year ahead to the next day in `TaskManagement`