### PR TITLE
refactor(ui): remove designation mode from employee components

### DIFF
--- a/src/app/content/user/components/EmployeeCard.jsx
+++ b/src/app/content/user/components/EmployeeCard.jsx
@@ -6,7 +6,7 @@ import Image from '../../../../components/AppImage';
 import Icon from '../../../../components/AppIcon';
 import { Button } from '../../../../components/ui/button';
 
-const EmployeeCard = ({ employee, onViewProfile, onEdit, isDesignationMode = false }) => {
+const EmployeeCard = ({ employee, onViewProfile, onEdit}) => {
   const [showActions, setShowActions] = useState(null);
   const [clickedButtonRect, setClickedButtonRect] = useState(null);
   const fallbackImage =
@@ -93,7 +93,7 @@ const EmployeeCard = ({ employee, onViewProfile, onEdit, isDesignationMode = fal
                 {employee.full_name}
               </h3>
               <p className="text-sm text-muted-foreground">{employee.mobile}</p>
-              <p className="text-sm text-muted-foreground">{isDesignationMode ? 'Designation' : 'Role'}: {isDesignationMode ? employee.designation : employee.profile_name}</p>
+              <p className="text-sm text-muted-foreground">{employee.profile_name}</p>
             </div>
 
             <div className="relative">

--- a/src/app/content/user/components/EmployeeTable.jsx
+++ b/src/app/content/user/components/EmployeeTable.jsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect } from 'react';
 import DataTable from 'react-data-table-component';
 import Image from '../../../../components/AppImage';
 import Icon from '../../../../components/AppIcon';
@@ -60,8 +60,7 @@ const EmployeeTable = ({
   onSelectEmployee,
   onSelectAll,
   onSort,
-  sortConfig,
-  isDesignationMode = false
+  sortConfig
 }) => {
   const [showActions, setShowActions] = useState(null);
   const [menuCoords, setMenuCoords] = useState({ top: 0, left: 0 });
@@ -213,7 +212,7 @@ const EmployeeTable = ({
     },
   };
 
-  const columns = useMemo(() => [
+  const columns = [
         {
       name: (
         <div>
@@ -300,7 +299,7 @@ const EmployeeTable = ({
       sortable: true,
       omit: window.innerWidth < 1024 // Hide on mobile
     },
-    ...(isDesignationMode ? [{
+    {
       name: (
         <div>
           <div>Designation</div>
@@ -320,29 +319,7 @@ const EmployeeTable = ({
       ),
       selector: row => row.designation,
       sortable: true,
-      omit: window.innerWidth < 1280 // Hide on smaller screens
-    }] : [{
-      name: (
-        <div>
-          <div>Role</div>
-          <input
-            type="text"
-            placeholder="Search..."
-            onChange={(e) => handleColumnFilter("profile_name", e.target.value)}
-            style={{
-              width: "100%",
-              padding: "4px",
-              fontSize: "12px",
-
-              marginTop: "5px"
-            }}
-          />
-        </div>
-      ),
-      selector: row => row.profile_name,
-      sortable: true,
-      omit: window.innerWidth < 1280 // Hide on smaller screens
-    }]),
+    },
     {
       name: (
         <div>
@@ -416,7 +393,7 @@ const EmployeeTable = ({
       button: true,
       width: "80px"
     },
-  ], [isDesignationMode]);
+  ]
 
   return (
     <div className="bg-card rounded-lg overflow-hidden">


### PR DESCRIPTION
Remove `isDesignationMode` prop and associated conditional logic from `EmployeeCard` and `EmployeeTable`. This simplifies the component interfaces by standardizing on `profile_name` and removing the toggleable designation column in the table.