### PR TITLE
feat(offer-management): include department name in offer workflow and…

### DIFF
--- a/src/app/content/Telent-management/Offer-management/OfferDashboard.tsx
+++ b/src/app/content/Telent-management/Offer-management/OfferDashboard.tsx
@@ -65,7 +65,7 @@ export default function OfferDashboard({ showHeader = true, candidate, position,
   const router = useRouter();
   const [offers, setOffers] = useState<Offer[]>([]);
   const [templates, setTemplates] = useState<OfferTemplate[]>([]);
-  const [positions, setPositions] = useState<{ id: number, title: string, benefits: string }[]>([]);
+  const [positions, setPositions] = useState<{ id: number, title: string, benefits: string, department_name: string }[]>([]);
   const [managers, setManagers] = useState<{ id: number, name: string }[]>([]);
   const [selectedOffer, setSelectedOffer] = useState<Offer | null>(null);
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
@@ -364,7 +364,12 @@ export default function OfferDashboard({ showHeader = true, candidate, position,
 
         if (positionsResponse.ok) {
           const positionsResult = await positionsResponse.json();
-          setPositions(positionsResult.data || []);
+          setPositions(positionsResult.data.map((item: any) => ({
+            id: item.id,
+            title: item.title,
+            benefits: item.benefits,
+            department_name: item.department_name
+          })) || []);
         } else {
           setPositions([]);
         }
@@ -599,6 +604,10 @@ export default function OfferDashboard({ showHeader = true, candidate, position,
       }
 
       if (templateId) {
+        // Get department_name from selected position
+        const selectedPosition = positions.find(p => p.id.toString() === newOffer.jobId);
+        const departmentName = selectedPosition?.department_name || '';
+
         // Prepare offer data for template
         const offerData = {
           candidateId: newOffer.candidateId,
@@ -612,6 +621,7 @@ export default function OfferDashboard({ showHeader = true, candidate, position,
           workScheduleStart: newOffer.workScheduleStart,
           workScheduleEnd: newOffer.workScheduleEnd,
           keyResponsibility: newOffer.keyResponsibility,
+          department_name: departmentName,
           employeeData,
           companyData,
           // hrData,

--- a/src/app/content/hr-templates/editor/[templateId]/Component/Template.tsx
+++ b/src/app/content/hr-templates/editor/[templateId]/Component/Template.tsx
@@ -114,7 +114,7 @@ export default function EditorPage({ params }: { params: Promise<{ templateId: s
                 '{{company_cin}}': data.company_cin || data.companyData?.cin || '',
                 '{{company_gstin}}': data.company_gstin || data.companyData?.gstin || '',
                 '{{company_pan}}': data.company_pan || data.companyData?.pan || '',
-                '{{department_name}}': data.selectedDepartment || data.employeeData?.department_name || '',
+                 '{{department_name}}': data.department_name || data.selectedDepartment || data.employeeData?.department_name || '',
                 '{{hr_name}}': data.hrData?.name || '',
                 '{{hr_designation}}': data.hrData?.designation || '',
                 '{{hr_email}}': data.hrData?.email || '',


### PR DESCRIPTION
… templates

Update the offer management workflow to include `department_name` in the position data and ensure it is correctly passed to the template engine.

- Update `OfferDashboard` to fetch and store `department_name` from positions
- Map `department_name` to the offer data object when preparing template data
- Update `Template` component to prioritize `department_name` from the provided offer data for placeholder replacement