### PR TITLE
feat: add support for job role tasks and responsibilities queries

### DIFF
--- a/src/app/api-handler.ts
+++ b/src/app/api-handler.ts
@@ -1240,6 +1240,19 @@ async function handleSkillsAndJobRolesRequest(
   entities: any
 ): Promise<ChatResponse> {
   try {
+    // For JOB_ROLE_TASKS_FETCH, require jobRole - otherwise prompt conversationally (like skills flow)
+    if (intent === 'JOB_ROLE_TASKS_FETCH' && !(entities && entities.jobRole)) {
+      await saveMessage(conversationId, 'bot', 'Please enter the job role name.', intent);
+      return {
+        answer: "Please enter the job role name.",
+        conversationId,
+        intent,
+        action: 'ASK_JOB_ROLE_FOR_TASKS',
+        recoverable: true,
+        suggestion: 'Please provide the job role name to list its tasks and responsibilities.',
+      };
+    }
+
     let apiKey: string;
     let method: "GET" | "POST" = "GET";
     let body: any = {};
@@ -1285,6 +1298,14 @@ async function handleSkillsAndJobRolesRequest(
       apiKey = intentToApiMap[intent] || 'skill_library';
     }
 
+    // Support dynamic jobrole filter for JOB_ROLE_TASKS_FETCH (e.g. "What are the job responsibilities")
+    if (intent === 'JOB_ROLE_TASKS_FETCH') {
+      params[`filters[sub_institute_id]`] = request.subInstituteId;
+      if (entities && entities.jobRole) {
+        params[`filters[jobrole]`] = entities.jobRole;
+      }
+    }
+
     const apiEntry = hpApiMap[apiKey];
     if (!apiEntry) {
       throw new Error(`No API mapping found for intent: ${intent}`);
@@ -1304,6 +1325,16 @@ async function handleSkillsAndJobRolesRequest(
     // Filter data to show only jobrole field for JOB_ROLES_FETCH and JOB_ROLES_FOR_DEPARTMENT_FETCH
     if ((intent === 'JOB_ROLES_FETCH' || intent === 'JOB_ROLES_FOR_DEPARTMENT_FETCH') && Array.isArray(data)) {
       data = data.map(item => ({ jobrole: item.jobrole || 'N/A' }));
+    }
+
+    // Clean mapping for JOB_ROLE_TASKS_FETCH to match dept job roles list UI (only name + cwf, no raw DB noise)
+    if (intent === 'JOB_ROLE_TASKS_FETCH' && Array.isArray(data)) {
+      data = data.map((item: any) => ({
+        id: item.id || null,
+        name: item.task || item.responsibility || item.description || 'Task',
+        criticalWorkFunction: item.critical_work_function || item.cwf || '',
+        jobrole: item.jobrole || entities?.jobRole || ''
+      }));
     }
 
     // Generate SQL and apply filters for JOB_ROLES_FETCH and JOB_ROLES_FOR_DEPARTMENT_FETCH
@@ -1331,6 +1362,16 @@ async function handleSkillsAndJobRolesRequest(
       tablesUsed = ['skill_library'];
     } else if (intent === 'JOB_ROLES_FETCH' || intent === 'JOB_ROLES_FOR_DEPARTMENT_FETCH') {
       tablesUsed = ['s_user_jobrole'];
+    } else if (intent === 'JOB_ROLE_TASKS_FETCH') {
+      tablesUsed = ['s_user_jobrole_task'];
+      if (entities && entities.jobRole) {
+        sql = `SELECT * FROM s_user_jobrole_task WHERE sub_institute_id = ${request.subInstituteId} AND jobrole = '${String(entities.jobRole).replace(/'/g, "''")}';`;
+      } else {
+        sql = `SELECT * FROM s_user_jobrole_task WHERE sub_institute_id = ${request.subInstituteId};`;
+      }
+      customAnswerText = entities?.jobRole
+        ? `Found ${Array.isArray(data) ? data.length : 0} task(s) for job role "${entities.jobRole}".`
+        : `Found ${Array.isArray(data) ? data.length : 0} job role task(s).`;
     }
 
     return createStructuredResponse(intent, Array.isArray(data) ? data : (data ? [data] : []), request.query, getIntentQuerySuggestions(intent), sql, tablesUsed, customAnswerText);
@@ -1379,8 +1420,14 @@ async function handleOrganizationAndIndustriesRequest(
       }
     }
 
+    if (intent === 'JOB_ROLES_FOR_DEPARTMENT_FETCH') {
+      apiKey = 's_user_jobrole';
+      params[`filters[sub_institute_id]`] = request.subInstituteId;
+      if (entities.department) {
+        params[`filters[department]`] = entities.department;
+      }
+    }
 
-    // Add path parameters for Neo4J endpoints
     if (entities.industrySlug && intent === 'DEPARTMENTS_FOR_INDUSTRY_FETCH') {
       apiKey = apiKey.replace('{slug}', entities.industrySlug);
     }
@@ -1397,8 +1444,10 @@ async function handleOrganizationAndIndustriesRequest(
 
     await saveMessage(conversationId, 'bot', `Retrieved ${Array.isArray(data) ? data.length : (data ? 1 : 0)} organization/industries record(s)`, intent);
 
-    // Filter data to show only jobrole field for USER_JOB_ROLES_FETCH
     if (intent === 'USER_JOB_ROLES_FETCH' && Array.isArray(data)) {
+      data = data.map(item => ({ jobrole: item.jobrole || 'N/A' }));
+    }
+    if (intent === 'JOB_ROLES_FOR_DEPARTMENT_FETCH' && Array.isArray(data)) {
       data = data.map(item => ({ jobrole: item.jobrole || 'N/A' }));
     }
 
@@ -2024,7 +2073,7 @@ const hpApiMap: Record<string, { method: "GET" | "POST"; url: string }> = {
   "jobroleSkill_create": { method: "POST", url: "https://erp.triz.co.in/skill/jobroleSkill" },
   "jobroleSkill_update": { method: "POST", url: "https://erp.triz.co.in/skill/jobroleSkill/{id}" },
 
-  "jobroleTask": { method: "GET", url: "https://erp.triz.co.in/skill/jobroleTask" },
+  "jobroleTask": { method: "GET", url: "https://hp.triz.co.in/table_data?table=s_user_jobrole_task" },
   "jobroleTask_create": { method: "POST", url: "https://erp.triz.co.in/skill/jobroleTask" },
 
   // -----------------------
@@ -2939,6 +2988,51 @@ export async function handleChatRequest(request: ChatRequest): Promise<ChatRespo
           intent: intent.intent,
           action: 'REDIRECT',
           redirectUrl: '/content/HRMS/Leave-Management/Holiday-Master',
+          recoverable: true
+        };
+      } else if (lowerQuery.includes('skill') || lowerQuery.includes('create a new skill')) {
+        return {
+          answer: `Navigation: Libraries → Skill Library\n\nYou can create and manage skills from this page. Redirecting now...`,
+          conversationId,
+          intent: intent.intent,
+          action: 'REDIRECT',
+          redirectUrl: '/content/Libraries/skillLibrary',
+          recoverable: true
+        };
+      } else if (lowerQuery.includes('job role') && (lowerQuery.includes('create') || lowerQuery.includes('add'))) {
+        return {
+          answer: `Navigation: Libraries → Skill Library → Job Roles\n\nYou can create and manage job roles from this page. Redirecting now...`,
+          conversationId,
+          intent: 'Add New Job Role',
+          action: 'REDIRECT',
+          redirectUrl: '/content/Libraries/skillLibrary',
+          recoverable: true
+        };
+      } else if (lowerQuery.includes('department') && (lowerQuery.includes('create') || lowerQuery.includes('add'))) {
+        return {
+          answer: `Navigation: Organization Profile Management → Departments\n\nYou can add and manage departments from this page. Redirecting now...`,
+          conversationId,
+          intent: intent.intent,
+          action: 'REDIRECT',
+          redirectUrl: '/content/organization-profile-management',
+          recoverable: true
+        };
+      } else if ((lowerQuery.includes('task') && (lowerQuery.includes('create') || lowerQuery.includes('add'))) || lowerQuery.includes('add new task')) {
+        return {
+          answer: `Navigation: Task Management → Tasks\n\nYou can add and manage tasks for job roles from this page. Redirecting now...`,
+          conversationId,
+          intent: intent.intent,
+          action: 'REDIRECT',
+          redirectUrl: '/content/task',
+          recoverable: true
+        };
+      } else if (lowerQuery.includes('course') || lowerQuery.includes('enroll')) {
+        return {
+          answer: `Navigation: LMS → Courses\n\nYou can enroll in the selected course from this page. Redirecting now...`,
+          conversationId,
+          intent: intent.intent,
+          action: 'REDIRECT',
+          redirectUrl: '/content/LMS',
           recoverable: true
         };
       } else if (lowerQuery.includes('payroll')) {

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -56,23 +56,62 @@ export async function POST(request: Request) {
         const rawQuery = body.query || '';
         const departmentPattern = /^select my department\s+(?:as\s+|in\s+)?(.+?)(?:\s+industry)?$/i;
         const departmentMatch = rawQuery.match(departmentPattern);
-        
-        // Check if this is a "Selected Industry as X" pattern (new format from frontend)
         const selectedIndustryPattern = /^selected industry\s+as\s+(.+)$/i;
         const selectedIndustryMatch = rawQuery.match(selectedIndustryPattern);
-        
-        // Check if user selected a department (e.g., "selected department: design" or "department: design")
         const selectedDeptPattern = /^(?:selected )?department[:\s]+(.+)$/i;
         const selectedDeptMatch = rawQuery.match(selectedDeptPattern);
-        
-        // Check if this is a "Select my job role as X" or "Select my job role in X department" pattern
         const jobRolePattern = /^select (?:my )?job role\s+(?:as\s+|in\s+)?(.+?)(?:\s+department)?$/i;
         const jobRoleMatch = rawQuery.match(jobRolePattern);
-        
-        // Check if this is a "Select my skills for X" or "select my jobrole as X" pattern
-        // This directly calls the skills API after job role is selected
         const skillsPattern = /^(?:select\s+(?:my\s+)?)?(?:skills\s+for|jobrole\s+as)\s+(.+)$/i;
         const skillsMatch = rawQuery.match(skillsPattern);
+        const showJobRolesSpecificDeptPattern = /show (?:me )?job roles? (?:for|in) (?:a |the )?specific department/i;
+        const showJobRolesForDeptPattern = /show (?:me )?job roles? (?:for|in) (.+?)(?:\s+department)?$/i;
+        const lastAssistant = (body.conversationHistory && Array.isArray(body.conversationHistory)) ? [...body.conversationHistory].reverse().find((m: any) => m && m.role === 'assistant' && m.content) : null;
+        const isDeptFollowup = !!(lastAssistant && /please enter the department name/i.test(lastAssistant.content || ''));
+        const showJobRolesSpecificDeptMatch = rawQuery.match(showJobRolesSpecificDeptPattern);
+        const showJobRolesForDeptMatch = rawQuery.match(showJobRolesForDeptPattern);
+        const showJobRoleSkillsPattern = /show (?:me )?(?:job role|jobrole) skills/i;
+        const showJobRoleSkillsForPattern = /show (?:me )?(?:job role|jobrole) skills (?:for|of) (.+)/i;
+        const showJobRoleSkillsMatch = rawQuery.match(showJobRoleSkillsPattern);
+        const showJobRoleSkillsForMatch = rawQuery.match(showJobRoleSkillsForPattern);
+
+        // Job role tasks / responsibilities patterns (for "What are the job responsibilities" flow)
+        const showJobRoleTasksPattern = /(?:show (?:me )?)?(?:job role|jobrole|position)? tasks?/i;
+        const showJobRoleTasksForPattern = /(?:show (?:me )?)?(?:job role|jobrole) tasks? (?:for|of) (.+)/i;
+        const jobResponsibilitiesPattern = /(?:what are the |list |show |get )?(?:job )?responsibilit(?:y|ies)/i;
+        const jobResponsibilitiesForPattern = /(?:responsibilit(?:y|ies)|duties|tasks?) (?:for|of) (?:the |a )?(.+)/i;
+        const showJobRoleTasksMatch = rawQuery.match(showJobRoleTasksPattern);
+        const showJobRoleTasksForMatch = rawQuery.match(showJobRoleTasksForPattern);
+        const jobRespMatch = rawQuery.match(jobResponsibilitiesPattern);
+        const jobRespForMatch = rawQuery.match(jobResponsibilitiesForPattern);
+
+        // Determine if the "Please enter the job role name." followup is for skills or tasks/responsibilities
+        // by inspecting the conversation history (what triggered the prompt)
+        let pendingJobRoleFollowupType: 'skills' | 'tasks' | null = null;
+        if (lastAssistant && /please enter the job role name/i.test(lastAssistant.content || '')) {
+          const history: any[] = (body.conversationHistory && Array.isArray(body.conversationHistory)) ? body.conversationHistory : [];
+          // Find the user query that led to the prompt (the one before the prompt in history)
+          for (let i = history.length - 1; i >= 0; i--) {
+            const m = history[i];
+            if (m && m.role === 'assistant' && /please enter the job role name/i.test(m.content || '')) {
+              // look at previous message (should be user)
+              if (i > 0) {
+                const prev = history[i - 1];
+                if (prev && prev.role === 'user' && prev.content) {
+                  const prevQ = String(prev.content).toLowerCase();
+                  if (/responsib|task.*role|job.*task|duties|responsibilities/i.test(prevQ)) {
+                    pendingJobRoleFollowupType = 'tasks';
+                  } else if (/skill/i.test(prevQ)) {
+                    pendingJobRoleFollowupType = 'skills';
+                  }
+                }
+              }
+              break;
+            }
+          }
+        }
+        const isJobRoleTasksFollowup = pendingJobRoleFollowupType === 'tasks' || !!(lastAssistant && /please enter the job role name/i.test(lastAssistant.content || '') && /task|responsib/i.test( (body.conversationHistory||[]).slice(-2).map((x:any)=>x?.content||'').join(' ') ));
+        const isJobRoleSkillsFollowup = pendingJobRoleFollowupType === 'skills' || (pendingJobRoleFollowupType === null && !!(lastAssistant && /please enter the job role name/i.test(lastAssistant.content || '')));
 
         // Check if this is a month response for attendance (e.g., "January", "January 2025", "current month", "current")
         const monthPattern = /^(?:for\s+)?(?:(january|february|march|april|may|june|july|august|september|october|november|december|current(?:\s+month)?)(?:\s+(\d{4}))?)$/i;
@@ -91,7 +130,7 @@ export async function POST(request: Request) {
 
         const punchOutPattern = /^punch out for the day$/i;
         const punchOutMatch = rawQuery.match(punchOutPattern);
-        
+
         if (departmentMatch && departmentMatch[1]) {
             // Extract industry name from the query
             const industry = departmentMatch[1].trim();
@@ -481,17 +520,110 @@ export async function POST(request: Request) {
                 actionType: 'navigateTo'
             };
         } else if (attendanceMatch) {
-            // Generic attendance update fallback
-            console.log('[chat] Detected generic attendance update request');
-
             result = {
                 answer: "Navigation: Attendance Module → Attendance\n\nI'll help you with attendance. Redirecting now...",
                 action: 'REDIRECT',
                 redirectUrl: '/content/my-attendance?intent=attendance',
                 actionType: 'navigateTo'
             };
+        } else if (isDeptFollowup || (showJobRolesForDeptMatch && showJobRolesForDeptMatch[1] && !/specific/i.test(showJobRolesForDeptMatch[1]))) {
+            const department = isDeptFollowup ? rawQuery.trim() : (showJobRolesForDeptMatch ? showJobRolesForDeptMatch[1].trim() : '');
+            const subInstituteIdVal = body.subInstituteId || '';
+            try {
+                const subInstituteIdParam = subInstituteIdVal ? `&filters[sub_institute_id]=${subInstituteIdVal}` : '';
+                const apiUrl = `https://hp.triz.co.in/table_data?table=s_user_jobrole&filters[department]=${encodeURIComponent(department)}${subInstituteIdParam}&group_by=jobrole`;
+                const fetchRes = await fetch(apiUrl);
+                if (!fetchRes.ok) throw new Error('Failed to fetch');
+                const fetchData = await fetchRes.json();
+                let rows = Array.isArray(fetchData) ? fetchData : (fetchData.data || fetchData.result || []);
+                if (subInstituteIdVal) {
+                    rows = rows.filter((r: any) => String(r.sub_institute_id) === String(subInstituteIdVal));
+                }
+                const jobRoleList = rows.map((r: any) => ({ id: r.id || null, name: r.jobrole || r.job_role || r.name || 'Unknown' }));
+                result = {
+                    answer: `Job roles related to the ${department} department:`,
+                    data: jobRoleList,
+                    selectionOptions: jobRoleList,
+                    currentStep: 'jobRoles',
+                    action: 'SHOW_JOB_ROLES'
+                };
+            } catch (e) {
+                result = { answer: `Could not fetch job roles for ${department}.` };
+            }
+        } else if (showJobRolesSpecificDeptMatch) {
+            result = {
+                answer: "Please enter the department name.",
+                currentStep: 'departmentForJobRoles',
+                nextStep: 'fetchJobRoles',
+                action: 'ASK_DEPARTMENT_FOR_JOB_ROLES'
+            };
+        } else if (isJobRoleSkillsFollowup || (showJobRoleSkillsForMatch && showJobRoleSkillsForMatch[1])) {
+            const jobRole = isJobRoleSkillsFollowup ? rawQuery.trim() : (showJobRoleSkillsForMatch ? showJobRoleSkillsForMatch[1].trim() : '');
+            const subInstituteIdVal = body.subInstituteId || '';
+            try {
+                const skillsResponse = await fetch(new URL('/api/get-skills-by-job-role', request.url).toString(), {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ jobRole, sub_institute_id: subInstituteIdVal })
+                });
+                if (!skillsResponse.ok) throw new Error('Failed to fetch skills');
+                const skillsData = await skillsResponse.json();
+                const skillsList = skillsData.data || [];
+                result = {
+                    answer: `Skills for the job role ${jobRole}:`,
+                    data: skillsList,
+                    selectionOptions: skillsList,
+                    currentStep: 'skills',
+                    action: 'SHOW_JOB_ROLE_SKILLS'
+                };
+            } catch (e) {
+                result = { answer: `Could not fetch skills for job role ${jobRole}.` };
+            }
+        } else if (showJobRoleSkillsMatch) {
+            result = {
+                answer: "Please enter the job role name.",
+                currentStep: 'jobRoleForSkills',
+                nextStep: 'fetchSkills',
+                action: 'ASK_JOB_ROLE_FOR_SKILLS'
+            };
+        } else if (isJobRoleTasksFollowup || (showJobRoleTasksForMatch && showJobRoleTasksForMatch[1]) || (jobRespForMatch && jobRespForMatch[1])) {
+            const jobRole = isJobRoleTasksFollowup ? rawQuery.trim() : (showJobRoleTasksForMatch ? showJobRoleTasksForMatch[1].trim() : (jobRespForMatch ? jobRespForMatch[1].trim() : ''));
+            const subInstituteIdVal = body.subInstituteId || '';
+            try {
+                const subInstituteIdParam = subInstituteIdVal ? `&filters[sub_institute_id]=${encodeURIComponent(subInstituteIdVal)}` : '';
+                const apiUrl = `https://hp.triz.co.in/table_data?table=s_user_jobrole_task&filters[jobrole]=${encodeURIComponent(jobRole)}${subInstituteIdParam}`;
+                const fetchRes = await fetch(apiUrl);
+                if (!fetchRes.ok) throw new Error('Failed to fetch tasks');
+                const fetchData = await fetchRes.json();
+                let taskRows = Array.isArray(fetchData) ? fetchData : (fetchData.data || fetchData.result || fetchData.rows || []);
+                if (subInstituteIdVal) {
+                    taskRows = taskRows.filter((r: any) => String(r.sub_institute_id) === String(subInstituteIdVal));
+                }
+                // Map to clean {id, name, ...} like dept job roles list for identical UI rendering (no raw DB fields)
+                const taskList = taskRows.map((r: any) => ({
+                  id: r.id || null,
+                  name: r.task || r.responsibility || r.description || r.key_responsibility || (typeof r === 'string' ? r : 'Task'),
+                  criticalWorkFunction: r.critical_work_function || r.cwf || '',
+                  jobrole: r.jobrole || jobRole
+                }));
+                result = {
+                    answer: `Job responsibilities/tasks for "${jobRole}":`,
+                    data: taskList,
+                    selectionOptions: taskList,
+                    currentStep: 'tasks',
+                    action: 'SHOW_JOB_ROLE_TASKS'
+                };
+            } catch (e) {
+                result = { answer: `Could not fetch responsibilities for job role ${jobRole}.` };
+            }
+        } else if (showJobRoleTasksMatch || jobRespMatch) {
+            result = {
+                answer: "Please enter the job role name.",
+                currentStep: 'jobRoleForTasks',
+                nextStep: 'fetchTasks',
+                action: 'ASK_JOB_ROLE_FOR_TASKS'
+            };
         } else {
-            // Normal chat flow
             try {
                 result = await handleChatRequest({
                     query: body.query,
@@ -502,10 +634,10 @@ export async function POST(request: Request) {
                     selectedJobRole: jobRole || undefined,
                     selectedjobRoleId: jobRoleId || undefined
                 });
-
+ 
             } catch (innerError) {
                 console.error("[handleChatRequest ERROR]:", innerError);
-
+ 
                 result = {
                     answer: "I ran into an issue, but I'm still here — try asking in simpler words!",
                     error: innerError instanceof Error ? innerError.message : "Unknown internal error",

--- a/src/lib1/intent-classifier.ts
+++ b/src/lib1/intent-classifier.ts
@@ -120,7 +120,6 @@ const intentPatterns: Record<QueryIntent, string[]> = {
     // Primary triggers - competency framework
     'generate competency profile',
     'competency profile for',
-    'job role responsibilities',
     'skills for',
     'competency framework',
     'CWFKT',
@@ -128,7 +127,6 @@ const intentPatterns: Record<QueryIntent, string[]> = {
     'key tasks',
     // Role exploration patterns
     'what does a',
-    'what are the responsibilities of',
     'role requirements',
     // Proficiency and skills
     'proficiency level',
@@ -357,9 +355,12 @@ const intentPatterns: Record<QueryIntent, string[]> = {
    JOB_ROLE_SKILL_CREATE: [
      'create job role skill', 'add job role skill'
    ],
-   JOB_ROLE_TASKS_FETCH: [
-     'show job role tasks', 'job role tasks', 'tasks for job role'
-   ],
+    JOB_ROLE_TASKS_FETCH: [
+      'show job role tasks', 'job role tasks', 'tasks for job role',
+      'job responsibilities', 'what are the job responsibilities', 'responsibilities for',
+      'what are the responsibilities', 'list job responsibilities', 'responsibilities of',
+      'job duties', 'position responsibilities', 'tasks and responsibilities'
+    ],
    JOB_ROLE_TASK_CREATE: [
      'create job role task', 'add job role task'
    ],
@@ -479,6 +480,9 @@ export function extractEntities(query: string): ExtractedEntities {
     /competency[\s-]?profile[\s-]?for[\s-]?([a-zA-Z]+(?:\s+[a-zA-Z]+)*)/i,
     // Handle "for [job role] in" pattern
     /for[\s-]?([a-zA-Z]+(?:\s+[a-zA-Z]+)*)\s+in[\s-]/i,
+    // Handle responsibilities/tasks for role
+    /responsibilit(?:y|ies) (?:of|for) ([a-zA-Z]+(?:\s+[a-zA-Z]+)*)/i,
+    /tasks? (?:of|for) ([a-zA-Z]+(?:\s+[a-zA-Z]+)*)/i,
   ];
 
   for (const pattern of jobRolePatterns) {

--- a/src/lib1/structured-response.ts
+++ b/src/lib1/structured-response.ts
@@ -273,12 +273,100 @@ export function createIntelligentQueryResponse(
     }
   }
 
+  // For skill-related queries
+  if (query_lower.includes('skill') || query_lower.includes('competency')) {
+    if (Array.isArray(data)) {
+      if (data.length > 10) {
+        const hasLevel = data.length > 0 && 'level' in data[0];
+        const columns = hasLevel ?
+          [
+            { key: 'name', label: 'Skill Name' },
+            { key: 'level', label: 'Level' },
+            { key: 'category', label: 'Category' }
+          ] :
+          [
+            { key: 'name', label: 'Skill Name' },
+            { key: 'category', label: 'Category' }
+          ];
+        return createStructuredResponse([
+          createTextBlock(`Found ${data.length} skills/competencies.`),
+          createTableBlock(columns, data, { title: 'Skills & Competencies' })
+        ], { intent: 'data_retrieval' });
+      } else {
+        return createStructuredResponse([
+          createTextBlock(`Found ${data.length} skills/competencies.`),
+          createCardsBlock(data.map(skill => ({
+            id: skill.id || skill.name,
+            title: skill.name,
+            description: skill.description || skill.category,
+            tag: skill.category,
+            metadata: skill
+          })), { title: 'Skills & Competencies' })
+        ], { intent: 'list_items' });
+      }
+    }
+  }
+
+  // For task/responsibility queries (job role tasks flow - mirrors Skills & Competencies exactly)
+  if (query_lower.includes('task') || query_lower.includes('responsib') || query_lower.includes('duty')) {
+    if (Array.isArray(data)) {
+      if (data.length > 10) {
+        const columns = [
+          { key: 'name', label: 'Task / Responsibility' },
+          { key: 'criticalWorkFunction', label: 'Critical Work Function' }
+        ];
+        return createStructuredResponse([
+          createTextBlock(`Found ${data.length} tasks/responsibilities.`),
+          createTableBlock(columns, data, { title: 'Task' })
+        ], { intent: 'data_retrieval' });
+      } else {
+        return createStructuredResponse([
+          createTextBlock(`Found ${data.length} tasks/responsibilities.`),
+          createCardsBlock(data.map((t: any) => ({
+            id: t.id || t.name,
+            title: t.name,
+            description: t.criticalWorkFunction || t.jobrole || '',
+            tag: t.criticalWorkFunction || 'Task',
+            metadata: t
+          })), { title: 'Task' })
+        ], { intent: 'list_items' });
+      }
+    }
+  }
+
+  // For task/responsibility queries (job role tasks flow - mirrors Skills & Competencies exactly)
+  if (query_lower.includes('task') || query_lower.includes('responsib') || query_lower.includes('duty')) {
+    if (Array.isArray(data)) {
+      if (data.length > 10) {
+        const columns = [
+          { key: 'name', label: 'Task / Responsibility' },
+          { key: 'criticalWorkFunction', label: 'Critical Work Function' }
+        ];
+        return createStructuredResponse([
+          createTextBlock(`Found ${data.length} tasks/responsibilities.`),
+          createTableBlock(columns, data, { title: 'Task' })
+        ], { intent: 'data_retrieval' });
+      } else {
+        return createStructuredResponse([
+          createTextBlock(`Found ${data.length} tasks/responsibilities.`),
+          createCardsBlock(data.map((t: any) => ({
+            id: t.id || t.name,
+            title: t.name,
+            description: t.criticalWorkFunction || t.jobrole || '',
+            tag: t.criticalWorkFunction || 'Task',
+            metadata: t
+          })), { title: 'Task' })
+        ], { intent: 'list_items' });
+      }
+    }
+  }
+
   // For employee data (mock queries) - improved detection
   const isEmployeeData = (
     query_lower.includes('employee') ||
     query_lower.includes('show employee data') ||
     (Array.isArray(data) && data.length > 0 && data[0] && typeof data[0] === 'object' &&
-     ('name' in data[0] || 'email' in data[0] || 'role' in data[0] || 'occupation' in data[0]))
+     (('email' in data[0]) || ('occupation' in data[0]) || (query_lower.includes('employee') && 'name' in data[0])))
   );
 
   if (isEmployeeData && Array.isArray(data) && data.length > 0) {
@@ -329,43 +417,6 @@ export function createIntelligentQueryResponse(
       tables_used: ['employee_data'],
       answer: summaryText
     });
-  }
-
-  // For skill-related queries
-  if (query_lower.includes('skill') || query_lower.includes('competency')) {
-    if (Array.isArray(data)) {
-      if (data.length > 10) {
-        // Large dataset - use table
-        // Check if data has 'level' field, if not, use available fields
-        const hasLevel = data.length > 0 && 'level' in data[0];
-        const columns = hasLevel ?
-          [
-            { key: 'name', label: 'Skill Name' },
-            { key: 'level', label: 'Level' },
-            { key: 'category', label: 'Category' }
-          ] :
-          [
-            { key: 'name', label: 'Skill Name' },
-            { key: 'category', label: 'Category' }
-          ];
-        return createStructuredResponse([
-          createTextBlock(`Found ${data.length} skills/competencies.`),
-          createTableBlock(columns, data, { title: 'Skills & Competencies' })
-        ], { intent: 'data_retrieval' });
-      } else {
-        // Small dataset - use cards
-        return createStructuredResponse([
-          createTextBlock(`Found ${data.length} skills/competencies.`),
-          createCardsBlock(data.map(skill => ({
-            id: skill.id || skill.name,
-            title: skill.name,
-            description: skill.description || skill.category,
-            tag: skill.category,
-            metadata: skill
-          })), { title: 'Skills & Competencies' })
-        ], { intent: 'list_items' });
-      }
-    }
   }
 
   // For chart/visualization queries


### PR DESCRIPTION
Add full support for users to query for job role tasks and responsibilities:
- Expand JOB_ROLE_TASKS_FETCH intent patterns to cover common user phrases
- Add regex entity extraction for role-based task and responsibility queries
- Implement structured response formatting for task results matching skill flow
- Update API handler for task fetching with job role filtering and data mapping
- Add chat route detection and follow-up handling for job responsibility queries
- Update task API endpoint to correct production URL
- Add navigation redirects for creating new job tasks
- Refactor response handling to clean up redundant code