### PR TITLE
feat(mcp): add mariadb health check at server startup

### DIFF
--- a/apps/ai/mcp/datasource/mariadb.ts
+++ b/apps/ai/mcp/datasource/mariadb.ts
@@ -193,6 +193,34 @@ function summarizeDbError(error: any) {
   };
 }
 
+function classifyConnectionFailure(error: any) {
+  const code = String(error?.code || "");
+  const errno = Number(error?.errno);
+
+  if (code === "ER_ACCESS_DENIED_ERROR" || errno === 1045) {
+    return "auth";
+  }
+
+  if (code === "ER_BAD_DB_ERROR" || errno === 1049) {
+    return "database";
+  }
+
+  if (
+    code === "ETIMEDOUT" ||
+    code === "ECONNREFUSED" ||
+    code === "ECONNRESET" ||
+    code === "EHOSTUNREACH" ||
+    code === "ENETUNREACH" ||
+    errno === 45028 ||
+    errno === 2002 ||
+    errno === 2003
+  ) {
+    return "network";
+  }
+
+  return "unknown";
+}
+
 function buildConnectionDiagnostics(error: any) {
   return {
     target: `${dbConfig.host}:${dbConfig.port}/${dbConfig.database}`,
@@ -220,6 +248,39 @@ function wrapConnectionError(error: any, scope: "query" | "transaction") {
   (wrapped as Error & { cause?: unknown }).cause = error;
   (wrapped as Error & { diagnostics?: unknown }).diagnostics = diagnostics;
   return wrapped;
+}
+
+export async function checkMariaDbHealth() {
+  const startedAt = Date.now();
+  let conn: any;
+
+  try {
+    conn = await pool.getConnection();
+    await conn.query("SELECT 1 AS ok");
+
+    return {
+      ok: true,
+      target: `${dbConfig.host}:${dbConfig.port}/${dbConfig.database}`,
+      user: dbConfig.user,
+      durationMs: Date.now() - startedAt,
+      connectionLimit: poolConfig.connectionLimit,
+      sslEnabled: Boolean(poolConfig.ssl),
+      socketPath: poolConfig.socketPath || null,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      target: `${dbConfig.host}:${dbConfig.port}/${dbConfig.database}`,
+      user: dbConfig.user,
+      durationMs: Date.now() - startedAt,
+      failureType: classifyConnectionFailure(error),
+      diagnostics: buildConnectionDiagnostics(error),
+    };
+  } finally {
+    if (conn) {
+      conn.release?.();
+    }
+  }
 }
 
 async function acquireConnection() {

--- a/apps/ai/mcp/http-server.ts
+++ b/apps/ai/mcp/http-server.ts
@@ -1,6 +1,7 @@
 import { createServer, IncomingMessage } from "node:http";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { checkMariaDbHealth } from "./datasource/mariadb";
 import { registerQueryBusinessDataTool } from "./tools/registerQueryBusinessDataTool";
 
 async function readJsonBody(request: IncomingMessage) {
@@ -33,8 +34,23 @@ export async function startMCPServer() {
   });
 
   const PORT = Number(process.env.MCP_PORT || 3400);
+  const strictHealthCheck = ["1", "true", "yes", "on"].includes(
+    String(process.env.DB_HEALTHCHECK_STRICT || "").trim().toLowerCase()
+  );
 
   registerQueryBusinessDataTool(server);
+
+  const health = await checkMariaDbHealth();
+  if (health.ok) {
+    console.log("[mariadb] Health check passed", health);
+  } else {
+    console.error("[mariadb] Health check failed", health);
+    if (strictHealthCheck) {
+      throw new Error(
+        `MariaDB health check failed during startup (${health.failureType || "unknown"}).`
+      );
+    }
+  }
 
   const httpServer = createServer((req, res) => {
     void (async () => {


### PR DESCRIPTION
Implement MariaDB connectivity health check that runs during MCP server startup, add configurable strict failure mode via DB_HEALTHCHECK_STRICT environment variable, classify connection failure types, log health check results, and properly release database connections after checks.